### PR TITLE
Revert ""Magic overhead" changed from 8 to 28"

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -59,7 +59,7 @@ var app = new Vue({
       if (this.payload_len !== null) {
         let payload_bit = 8 * this.payload_len; // The lenght of payload in bits
         payload_bit -= 4 * this.spreading_factor; // ???
-        payload_bit += 28; // Mistry magic overhead
+        payload_bit += 8; // Mistry magic overhead
         payload_bit += this.crc ? 16 : 0; // The length of CRC is 16 bits
         payload_bit += this.explicit_header ? 20 : 0; // The length of LoRa header is 20 bits
         payload_bit = Math.max(payload_bit, 0);


### PR DESCRIPTION
This PR reverts commit 6d120f8c28b8c0e41e20f054ef19c0b754aa2004 from PR #2 to fix the symbol length calculation.

Adding `28` at this point depends on implementing the formula exactly as written in the SX1276 datasheet:

![image](https://user-images.githubusercontent.com/205573/210508400-9d900a79-42cf-44de-9e54-f54390796f5e.png)

Specifically the terms `+ 28` and `- 20 IH` (where IH = 1 for implicit header, 0 otherwise.)

However, in this code `20` is added again on line 64 to account for any explicit header.

```
payload_bit += this.explicit_header ? 20 : 0;
```

So the symbol count was correct before PR #2, and is now 20 symbols too long.

BTW, Semtech seem to have noticed the SX1276 equation is quite confusing(!) In the newer SX1262 datasheet the equation is written differently and seems clearer:

![image](https://user-images.githubusercontent.com/205573/210508775-ef95a4e2-c4cc-4909-94f3-586a8b8e2437.png)

The two terms mentioned have changed to the equivalent:

`+ 8 + Nsymbolheader` where Nsymbolheader = 20 for explicit header and 0 otherwise.

Which is the same as what is written in the original version of this calculator.

With this change applied, the "time on air" results I get from this calculator match the values in the SX1261 Windows calculator program [downloadable from Semtech here](https://lora-developers.semtech.com/documentation/product-documents/) [*]

Thanks for maintaining this calculator, it's a useful resource! :)

[*] Except for when using SF5 & SF6 which are incompatible between SX1262 and SX1276, but that is a different matter.